### PR TITLE
[FIX] XForms edits can now be saved

### DIFF
--- a/CORE/api/xforms.xqm
+++ b/CORE/api/xforms.xqm
@@ -42,9 +42,12 @@ function xforms:dump($body){
 declare
   %rest:path("/xforms/dump/{$workspace}")
   %rest:POST("{$body}")
-  %output:method("text")
-updating function xforms:dump($body, $workspace as xs:string){
-	db:output(serialize($body) || " has been saved!"), replace node db:open($workspace)//slot[@id = $body/@id] with $body
+  %output:method("xml")
+ updating  function xforms:dump($body, $workspace as xs:string){
+
+	db:output($body/slot),
+		replace node  db:open($workspace)//slot[@id = $body/slot/@id]
+	 with $body/slot
 };
 
 (:~

--- a/CORE/services/xforms-template.xqm
+++ b/CORE/services/xforms-template.xqm
@@ -12,13 +12,20 @@ declare function tmpl:body($workspace as xs:string, $model as element(), $bindin
 	return
 	<html xmlns="http://www.w3.org/1999/xhtml" xmlns:xf="http://www.w3.org/2002/xforms">
      <head>
+			<style type="text/css">
+			
+			</style>
         <title>Edit</title>
         <xf:model xmlns="">
            <xf:instance  xmlns="">
 							{ $id }
               { $model }
            	</xf:instance>
-          <xf:submission action="/restxq/xforms/dump/{$workspace}" id="dump" method="post" />
+          <xf:submission action="/restxq/xforms/dump/{$workspace}" replace="instance" id="dump" method="post">
+			    <xf:message ev:event="xforms-submit-error">A submission error (<output value="event('error-type')"/>) occurred.</xf:message>
+			    <xf:message level="ephemeral" ev:event="xforms-submit-done">Data has been successfully saved</xf:message>
+
+					</xf:submission>
           {$bindings}
         </xf:model>
 			  <style>


### PR DESCRIPTION
A save is performed at:
`%rest:path("/xforms/dump/{$workspace}")` with a POST containing the `<slot />`
