### PR TITLE
Node service new

### DIFF
--- a/CORE/api/nodes.xqm
+++ b/CORE/api/nodes.xqm
@@ -50,6 +50,43 @@ function api:get-node-stringify($type as xs:string,
 			$filters)
 };
 
+declare 
+%rest:GET
+%rest:path("/ws/{$type}/search/{$search}")
+%output:method("json")
+%rest:query-param("filter", "{$filter}", '')
+%rest:query-param("stringify", "{$str}", '')
+%rest:query-param("inherit", "{$inh}", '')
+%rest:query-param("expand", "{$exp}", '')
+
+function api:search($type as xs:string, $search as xs:string,
+	$filter as xs:string,
+	$str as xs:string,
+	$inh as xs:string,
+	$exp as xs:string){
+	<json objects="json node attributes property slot value">
+	{
+		let $filters	:= tokenize($filter, ","),
+			$inherit		:= fn:boolean($inh),
+			$expand			:= fn:boolean($exp),
+			$stringify	:= fn:boolean($str),
+			$nodes			:= nodes:search($type, $search)
+		return
+		jsonutil:jsonatts(
+		nodes:stringify(
+			nodes:filter(							(: remove unwanted properties :)
+		  	nodes:expand(					(: get properties from aside :)
+					nodes:inherit(			(: get properties from above :)
+							(: make properties string only :)
+							$nodes,$inherit),
+					$expand),
+				$filters),
+		 $stringify),
+			"attributes")
+		}</json>
+
+	(: <results>{nodes:stringify(, fn:true())}</results> :)
+};
 (:~ 
 : This resource returns a single node with all inherited attributes inlined
 : @param $uuid the UUID of the node to return

--- a/CORE/api/nodes.xqm
+++ b/CORE/api/nodes.xqm
@@ -24,8 +24,30 @@ declare
 %rest:GET
 %rest:path("/ws/{$type}/node/{$uuid}")
 %rest:produces("application/xml")
-function api:get-node($type as xs:string, $uuid as xs:string){
-   nodes:get-product($type, $uuid)
+%rest:query-param("filter", "{$filter}", '')
+%rest:query-param("stringify", "{$str}", '')
+%rest:query-param("inherit", "{$inh}", '')
+%rest:query-param("expand", "{$exp}", '')
+function api:get-node-stringify($type as xs:string,
+																$uuid as xs:string,
+																$filter as xs:string,
+																$str as xs:string,
+																$inh as xs:string,
+																$exp as xs:string){
+	let $filters	:= tokenize($filter, ","),
+		$inherit		:= fn:boolean($inh),
+		$expand			:= fn:boolean($exp),
+		$stringify	:= fn:boolean($str),
+		$nodes			:= nodes:get($type, $uuid)
+	return
+	nodes:filter(							(: remove unwanted properties :)
+	  	nodes:expand(					(: get properties from aside :)
+				nodes:inherit(			(: get properties from above :)
+					nodes:stringify(	(: make properties string only :)
+						$nodes, $stringify),
+					$inherit),
+				$expand),
+			$filters)
 };
 
 (:~ 

--- a/CORE/api/nodes.xqm
+++ b/CORE/api/nodes.xqm
@@ -14,6 +14,7 @@ import module namespace jsonutil = "http://basepim.org/jsonutil" at "../util/jso
 
 declare namespace rest = "http://exquery.org/ns/restxq";
 
+
 (:~ 
 : This resource returns a single node.
 : @param $type the name of the workspace
@@ -97,7 +98,7 @@ declare
 %rest:path("/ws/flat/{$uuid}")
 %rest:produces("application/xml")
 function api:flat($uuid as xs:string){
-	let $prod := nodes:get-product("ws_produkte", $uuid),
+	let $prod := nodes:get("ws_produkte", $uuid),
 		$map := nodes:flatten-product($prod)
 	return
 	(

--- a/CORE/services/node-service.xqm
+++ b/CORE/services/node-service.xqm
@@ -3,6 +3,31 @@ module namespace nodes = "http://basepim.org/nodes";
 (:~ the database instance, this should be refactored :)
 declare variable $nodes:db := db:open('ws_produkte'); 
 
+
+(:~ Removes unwanted slots.
+: @param $nodes the nodes
+: @param $filter
+:)
+declare function nodes:filter($nodes as element(node)+, $filter as xs:string*) as element(node)+{
+	if(count($filter)) then
+		for $node in $nodes
+		return element {"node"}{
+			$node/@*,
+			for $child in $node/*
+			let $name := name($child)
+			return switch($name)
+				case "node" return $child ! nodes:filter(., $filter)
+				case "property" return if($child/@name = $filter) then
+				 																element	{"property"}
+																				{$child/@*,
+																				 $child/*}
+																			else
+																				()
+				default return ()
+		}
+		else $nodes
+};
+
 (:~
 : Gets a single product identified by its uuid
 : @param $type the workspace to fetch data from

--- a/CORE/services/node-service.xqm
+++ b/CORE/services/node-service.xqm
@@ -30,6 +30,10 @@ declare function nodes:stringify($nodes as element(node)+, $stringify as xs:bool
 		}
 	else $nodes
 };
+(: Get inheritable properties from above. :)
+declare function nodes:inherit($nodes as element(node)+, $inherit as xs:boolean) as element(node)+{
+	$nodes
+};
 
 (:~ Removes unwanted slots.
 : @param $nodes the nodes

--- a/CORE/services/node-service.xqm
+++ b/CORE/services/node-service.xqm
@@ -1,6 +1,29 @@
 module namespace nodes = "http://basepim.org/nodes";
 import module namespace search = "http://basepim.org/search" at "search.xqm";
 
+(:
+: Pipeline for returning nodes:
+
+: * Window					=> node[position() le $m and position() gt $n], function($n, $m)
+:																																		$filter = ("dimensions", "bild")	
+
+: * Inherit					=> include all inherited properties,						$nodes ! inherit(., $filter)
+
+: * Expand					=> include referenced nodes											$nodes ! expand(., $filter)
+
+: * Filter					=> list of properties to be included with each node element 
+:																																		return $nodes ! 
+																																			element 	{"node"}
+																													    				{
+																																			./@*, 
+																													    				for $prop in ./property
+																													    				where $prop/@name = $filter
+																																			return $prop
+																													    				}
+: * Stringify 			=> textual representation of the slots
+:)
+
+
 (:~ the database instance, this should be refactored :)
 declare variable $nodes:db := db:open('ws_produkte'); 
 

--- a/CORE/services/node-service.xqm
+++ b/CORE/services/node-service.xqm
@@ -34,6 +34,23 @@ declare function nodes:stringify($nodes as element(node)+, $stringify as xs:bool
 declare function nodes:inherit($nodes as element(node)+, $inherit as xs:boolean) as element(node)+{
 	$nodes
 };
+(: Request referenced properties. :)
+declare function nodes:expand($nodes as element(node)+, $expand as xs:boolean) as element(node)+{
+	if($expand) then	
+	for $node in $nodes
+	return element {"node"}{
+		$node/@*,
+		for $child in $node/*
+		let $name := name($child)
+		return switch($name)
+			case "node" return if(not($child/@idref)) then 
+										$child ! nodes:expand(., fn:true()) 
+									else nodes:get($child/@idref)
+			case "property" return $child
+			default return ()
+	}
+	else $nodes
+};
 
 (:~ Removes unwanted slots.
 : @param $nodes the nodes

--- a/CORE/services/node-service.xqm
+++ b/CORE/services/node-service.xqm
@@ -9,7 +9,7 @@ declare variable $nodes:db := db:open('ws_produkte');
 : @param $uuid the unique identifier of the node
 : @return the product <node />
 :)
-declare function nodes:get-product($type as xs:string, $uuid as xs:string) as element(node){
+declare function nodes:get($type as xs:string, $uuid as xs:string) as element(node){
     try {
 			let $db := db:open($type)
     	return $db//node[@id eq $uuid]

--- a/CORE/services/node-service.xqm
+++ b/CORE/services/node-service.xqm
@@ -1,4 +1,5 @@
 module namespace nodes = "http://basepim.org/nodes";
+import module namespace search = "http://basepim.org/search" at "search.xqm";
 
 (:~ the database instance, this should be refactored :)
 declare variable $nodes:db := db:open('ws_produkte'); 
@@ -67,6 +68,29 @@ declare function nodes:get($type as xs:string, $uuid as xs:string) as element(no
 		}catch * {
 			 <node>Error!</node>
 		}
+};
+(:~
+: Gets a single product identified by its uuid by searching all workspaces
+: N.B. the $uuid has to be unique for this to work, 
+: otherwise the first matching node will be returned.
+: @param $uuid the unique identifier of the node
+: @return the product <node />
+:)
+declare function nodes:get($uuid as xs:string) as element(node){
+	(db:list()[starts-with(.,"ws_")] ! 
+		db:attribute(., $uuid)/parent::*:node
+	)[1]
+};
+
+(:~
+: *TODO*
+: @param $workspace the workspace to fetch the &lt;slot /&gt; from
+: @param $search the search string
+: @return matching nodes
+:)
+declare function nodes:search($workspace as xs:string,
+    $search as xs:string) as element(node)*{
+		search:search($workspace, $search)
 };
 
 (:~

--- a/CORE/services/search.xqm
+++ b/CORE/services/search.xqm
@@ -1,0 +1,63 @@
+(:~ 
+: This module provides the functions that control the Web presentation
+: of search forms
+:
+: @author Christian Grün
+: @author Maximilian Gärber
+: @author Alexander Holupirek
+: @author Michael Seiferle
+: @version 0.8
+:)
+module namespace search = "http://basepim.org/search";
+import module namespace nodes = "http://basepim.org/nodes" at "../services/node-service.xqm";
+import module namespace parse =
+  "http://basex.org/modules/parse" at "../services/search/parse.xqm";
+import module namespace retrieve =
+  "http://basex.org/modules/retrieve" at "../services/search/retrieve.xqm";
+import module namespace render =
+  "http://basex.org/modules/render" at "../services/search/render.xqm";
+import module namespace properties = "http://basepim.org/properties" at "../services/property-service.xqm";
+import module namespace jsonutil = "http://basepim.org/jsonutil" at "../util/jsonutil.xqm";
+
+declare namespace rest = "http://exquery.org/ns/restxq";
+
+(:~ 
+: This resource returns a single node.
+: @param $type the name of the workspace
+: @param $uuid the UUID of the node to return
+: @return a node
+:)
+declare
+function search:search($type as xs:string, $search as xs:string){
+	search:s($search, $type, "10", 0)
+};
+
+(:~
+ : Returns a HTML representation of the requested hits.
+ : @param $q query keywords
+ : @param $s index of first hit
+ : @param $h number of hits to be returned
+ : @param $f fuzzy flag
+ :)
+declare
+  %rest:GET
+  %rest:path("/klett/s")
+  %rest:form-param("q", "{$q}")
+  %rest:form-param("d", "{$d}")
+  %rest:form-param("h", "{$h}")
+  %rest:form-param("f", "{$f}", 0)
+  %output:method("xhtml")
+  function search:s(
+    $q as xs:string*,
+    $d as xs:string,
+    $h as xs:string,
+    $f as xs:integer) as element()* {
+
+  let $search := parse:parse($q, $d, $h, $f)
+  let $results := retrieve:retrieve($search)
+  return 
+    if($results) then (
+      render:render($results, $search)
+    ) else (
+    )
+};

--- a/CORE/services/search/parse.xqm
+++ b/CORE/services/search/parse.xqm
@@ -1,0 +1,40 @@
+module namespace M = "http://basex.org/modules/parse";
+
+(: Key for included search terms. :)
+declare variable $M:INCLUDED := 'INCLUDED';
+(: Key for excluded search terms. :)
+declare variable $M:EXCLUDED := 'EXCLUDED';
+(: Key for number of hits. :)
+declare variable $M:HITS := 'HITS';
+(: Key for database. :)
+declare variable $M:DATABASE := 'DATABASE';
+(: Fuzzy flag. :)
+declare variable $M:FUZZY := 'FUZZY';
+
+(:~
+ : Parses the query string and additional parameters and
+ : returns a map with all relevant information.
+ : @param $query query keywords
+ : @param $database database to be opened
+ : @param $hits  number of hits to be returned
+ : @param $fuzzy fuzzy flag
+ :)
+declare function M:parse(
+    $query    as xs:string,
+    $database as xs:string,
+    $hits     as xs:string,
+    $fuzzy    as xs:integer) as map(*) {
+
+	let $p := analyze-string($query, '("[^"]+")')
+	let $t := (
+		$p//*:match/*:group ! replace(text(), '"', ''),
+		$p//*:non-match ! tokenize(normalize-space(.), ' ')
+	)
+	return map {
+	  $M:INCLUDED := $t[not(starts-with(., '-'))],
+	  $M:EXCLUDED := $t[starts-with(., '-')] ! substring(., 2),
+	  $M:HITS     := try { xs:int($hits) } catch * { 10000000 },
+	  $M:DATABASE := $database,
+	  $M:FUZZY    := boolean($fuzzy)
+	}
+};

--- a/CORE/services/search/render.xqm
+++ b/CORE/services/search/render.xqm
@@ -1,0 +1,48 @@
+module namespace M = "http://basex.org/modules/render";
+
+import module namespace parse =
+  "http://basex.org/modules/parse" at "parse.xqm";
+
+(:~
+ : Renders a result view for the specified results.
+ : @param $results returned results
+ : @param $terms query terms
+ : @param $fuzzy fuzzy flag
+ : @param $hits number of results
+ :)
+declare function M:render(
+    $results as element()*,
+    $search as map(*)) as element()* {
+
+	for $node in $results 
+	where count($node/*[name(.)!="node"]) > 1
+	return element {name($node)}
+		{
+		$node/@*
+		,
+		for $n in $node/*
+		where name($n) != ("node")
+		return $n
+		
+		}
+};
+
+(:~
+ : Returns a text node in which all keywords have been highlighted.
+ : @param $terms query terms
+ : @param fuzzy fuzzy flag
+ : @param $text text to mark
+ :)
+declare function M:mark(
+    $text as item(),
+    $search as map(*)) {
+
+  let $fuzzy as xs:boolean := $search($parse:FUZZY)
+  let $terms as xs:string* := $search($parse:INCLUDED)
+  let $mark := 'emph'
+  let $text := copy $c := text { $text } modify () return $c
+  let $mark := if($fuzzy) then
+    ft:mark($text[. contains text { $terms } using fuzzy], $mark) else
+    ft:mark($text[. contains text { $terms }], $mark)
+  return if($mark) then $mark else $text
+};

--- a/CORE/services/search/retrieve.xqm
+++ b/CORE/services/search/retrieve.xqm
@@ -1,0 +1,88 @@
+module namespace M = "http://basex.org/modules/retrieve";
+
+import module namespace parse =
+  "http://basex.org/modules/parse" at "parse.xqm";
+
+(: Categories to search. :)
+declare variable $M:CATEGORIES := ('slot');
+(: Root node. :)
+declare variable $M:ROOT := 'node';
+
+(:~
+ : Returns the requested hits.
+ : @param $search search variables
+ :)
+declare function M:retrieve(
+    $search as map(*)) {
+
+  let $terms as xs:string* := $search($parse:INCLUDED)
+  let $exc   as xs:string* := $search($parse:EXCLUDED)
+  let $db    as xs:string  := $search($parse:DATABASE)
+  let $hits  as xs:integer := $search($parse:HITS)
+  let $fuzzy as xs:boolean := $search($parse:FUZZY)
+  return (
+    (: no search terms? show all results :)
+    if(empty($terms)) then db:open($db)/descendant::*[name() = $M:ROOT][.//Text] else
+    (: terms to be excluded? :)
+    if(empty($exc)) then M:retrieve-fast($search)
+    (: use full search? :)
+    else M:retrieve-all($search)
+  )[position() <= $hits]
+};
+
+(:~
+ : Returns the requested hits, using a fast approach.
+ : @param $search search variables
+ :)
+declare function M:retrieve-fast(
+    $search as map(*)) {
+
+  (: return one more result to indicate if more results follow :)
+  let $results := M:retrieve($search, 'all')
+  return if($results)
+         then $results
+         else M:retrieve-all($search)
+};
+
+(:~
+ : Returns the requested hits.
+ : @param $search search variables
+ :)
+declare function M:retrieve-all(
+    $search as map(*)) {
+
+  (: return one more result to indicate if more results follow :)
+  let $fuzzy as xs:boolean := $search($parse:FUZZY)
+  let $terms as xs:string* := $search($parse:INCLUDED)
+  let $exc   as xs:string* := $search($parse:EXCLUDED)
+  return
+    (: check if all terms occur in the relevant categories :)
+    M:retrieve($search, 'any')[
+       let $s := string-join(*[name() = $M:CATEGORIES], ' ')
+       return if($fuzzy)
+              then ($s contains text { $terms } all using fuzzy
+                         ftand ftnot { $exc} using fuzzy)
+              else ($s contains text { $terms } all
+                         ftand ftnot { $exc })]
+};
+
+(:~
+ : Returns the requested hits.
+ : @param $search search variables
+ : @param $mode search mode
+ :)
+declare function M:retrieve(
+    $search as map(*),
+    $mode  as xs:string) as element()* {
+
+   let $db    as xs:string  := $search($parse:DATABASE)
+   let $inc as xs:string* := $search($parse:INCLUDED)
+   let $exc as xs:string* := $search($parse:EXCLUDED)
+   let $fuzzy as xs:boolean := $search($parse:FUZZY)
+   let $options := map { 'fuzzy' := $fuzzy, 'mode' := $mode }
+   let $results := ft:search($db, $inc, $options)
+   return (if(empty($results) or empty($exc))
+           then trace($results, "ERSULTS")
+           else $results except ft:search($db, $exc, $options))
+     /ancestor::*[name() = $M:CATEGORIES]/ancestor::*[name() = $M:ROOT]
+};

--- a/CORE/util/jsonutil.xqm
+++ b/CORE/util/jsonutil.xqm
@@ -15,8 +15,9 @@ module namespace jsonutil = "http://basepim.org/jsonutil";
     </attributes>
  : </node>
  :)
-declare function jsonutil:attr-to-elem($elem as element(), $wrapper as xs:string ) as element() {
-
+declare function jsonutil:attr-to-elem($elems as element()+, $wrapper as xs:string ) as element()+ {
+	for $elem in $elems
+	return
     element {name($elem)} {
     
     (if($wrapper ne '') then element {$wrapper}{ jsonutil:atts-to-elems($elem/@*) }

--- a/CORE/util/jsonutil.xqm
+++ b/CORE/util/jsonutil.xqm
@@ -37,4 +37,22 @@ declare function jsonutil:atts-to-elems($atts as attribute()*) as element()* {
                         element { name($a) } { data($a)}
 };
 
-
+(:~ 
+: Micheee’s convenience function as I am too stupid to get the upper one working correctly for my purpose.
+: Converts even text() nodes, in order to preserve structure.
+:)
+declare function jsonutil:jsonatts($element as element()+, $wrapper as xs:string){
+	for $e in $element
+		return element {name($e)}{ 
+		 if($e/@*) then	element {$wrapper} {
+				 for $inner in $e/@*
+		 		return element  {name($inner)}
+				 								{$inner/string()}
+		 } else (),
+		for $inner in $e/(*,  text())
+			return typeswitch($inner)
+					case text() return <text>{$inner}</text>
+					case element(*) return jsonutil:jsonatts($inner, $wrapper)
+			 default return ()
+		}
+};

--- a/WWW/demo-data/ascherl/cmd_ascherlbilder.xml
+++ b/WWW/demo-data/ascherl/cmd_ascherlbilder.xml
@@ -1,0 +1,4 @@
+<command xmlns="http://basex.org/rest">
+<text>create index fulltext</text>
+<parameter name='encoding' value='ISO-8859-1'/>
+</command>

--- a/WWW/demo-data/ascherl/cmd_bilder.xml
+++ b/WWW/demo-data/ascherl/cmd_bilder.xml
@@ -1,0 +1,4 @@
+<command xmlns="http://basex.org/rest">
+<text>create index fulltext</text>
+<parameter name='encoding' value='ISO-8859-1'/>
+</command>

--- a/WWW/demo-data/ascherl/cmd_bootsmotoren.xml
+++ b/WWW/demo-data/ascherl/cmd_bootsmotoren.xml
@@ -1,0 +1,4 @@
+<command xmlns="http://basex.org/rest">
+<text>create index fulltext</text>
+<parameter name='encoding' value='ISO-8859-1'/>
+</command>

--- a/WWW/demo-data/ascherl/create.sh
+++ b/WWW/demo-data/ascherl/create.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Loads workspace documents into BaseX
+# (C) 2012 Alexander Holupirek <ah@basex.org> 
+for i in ws_*.xml; do 
+	echo "Create database via REST call (input: $i)"
+	curl -s -XPUT -T $i admin:admin@localhost:8984/rest/${i%.*}; 
+done
+echo "Database path is defined in ../WEB-INF/web.xml:"
+grep -C1 org.basex.dbpath ../../WEB-INF/web.xml
+echo "List of databases (../../DATA):"
+ls ../../../DATA

--- a/WWW/demo-data/ascherl/indices.sh
+++ b/WWW/demo-data/ascherl/indices.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Adds indices to selected databases into BaseX
+# (C) 2012 Alexander Holupirek <ah@basex.org> 
+for c in cmd_*.xml; do 
+	echo "Run Command on database via REST call (input: $c)"
+	l=`expr //$c : '.*/cmd_\(.*\)\.xml'`
+	curl  -XPOST -T $c admin:admin@localhost:8984/rest/ws_$l;
+done
+# echo "Database path is defined in ../WEB-INF/web.xml:"
+# grep -C1 org.basex.dbpath ../../WEB-INF/web.xml
+# echo "List of databases (../../DATA):"
+# ls ../../../DATA

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>org.basex</groupId>
       <artifactId>basex-api</artifactId>
-       <version>7.2.1-SNAPSHOT</version>
+       <version>7.2.2-SNAPSHOT</version>
    </dependency>
 <!-- betterform integration:: -->
    <dependency>


### PR DESCRIPTION
# General Changes

In order for the new stuff to work correctly make sure to run: 
- updated create script `ascherl/create.sh`
- added script for indices creation `ascherl/indices.sh`
# Changes: In file `node-service.xqm`
## `expand($nodes, $expand as xs:boolean)`

If `$expand` is set to `true` all `nodes/@idref` are replaced with their actual counterparts.

The counterparts are searched across all databases that have names starting with 'ws_'_
## `filter($nodes, $filter as xs:string+)`

If `$filter` contains at least one string, all properties whose `@name` is not in `$filter` are stripped from the node.
## `stringify($nodes, $stringify as xs:boolean)`

If `$stringify` is set to true, all slots are converted to slot/string()

This should be only used if structure is not of importance 
## `inherit($nodes, $inherit as xs:boolean)`

To be done...
# API Changes: In file `nodes.xqm`
- `get-product` renamed to `get`
- `/ws/{$type}/get/{$uuid}` now accepts several parameters (explanations see above) that can be used in arbitrary combinations (standalone, all, only some): 
  - `?filter=a,b,c` to filter properties [ws/ws_bootsmotoren/node/2250-d1e400453-346814?filter=name,Stichworte](http://localhost:8984/restxq/ws/ws_bootsmotoren/node/2250-d1e400453-346814**?filter=name,Stichworte**)
  - `?expand=*` to fetch referenced nodes [ws/ws_bootsmotoren/node/2250-d1e400453-346814?filter=name,Stichworte,file**&expand=1**](http://localhost:8984/restxq/ws/ws_bootsmotoren/node/2250-d1e400453-346814?filter=name,Stichworte,file&amp;expand=1)
  - `?inherit=*` to fetch inheritable nodes
  - `?stringify=*` to return a stringified result [ws/ws_bootsmotoren/node/2151-d1e391938-346691?filter=PB&**stringify=YES**](http://localhost:8984/restxq/ws/ws_bootsmotoren/node/2151-d1e391938-346691?filter=PB&amp;stringify=1)
- Added SEARCH, see
  - [.../search/Geschwindigkeitskontrolle?expand=1&stringify=1](http://localhost:8984/restxq/ws/ws_bootsmotoren/search/Geschwindigkeitskontrolle?expand=1&amp;stringify=1)
  - but make sure to keep stringify enabled, otherwise the JSON serialization will struggle
# Utility Stuff

I added a function that converts attributes to elements. 
It is slightly more concise than what we had, the old implementation failed for me.
It also converts mixed content like <a>fo<em>bar</em>o</a>.
Together with stringify() this makes sure there is no more mixed content.

``` xquery
<a>
  <text>fo</text>
  <em>
    <text>bar</text>
  </em>
  <text>o</text>
</a>
```

[See this gist for an example](https://gist.github.com/3184345dcdacdf4e5279)
